### PR TITLE
[At/2503] Pass compilation for several runtimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
  "zerocopy 0.7.35",
@@ -153,8 +153,8 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
- "hashbrown 0.15.2",
- "indexmap 2.8.0",
+ "hashbrown 0.15.3",
+ "indexmap 2.9.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -189,7 +189,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -201,11 +201,11 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -222,7 +222,7 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity",
 ]
 
@@ -316,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "approx"
@@ -340,7 +340,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -408,7 +408,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -513,7 +513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -551,7 +551,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -579,7 +579,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -636,7 +636,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -697,7 +697,7 @@ dependencies = [
  "ark-std 0.5.0",
  "digest 0.10.7",
  "rand_chacha 0.3.1",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "w3f-ring-proof",
  "zeroize",
 ]
@@ -769,8 +769,8 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
- "synstructure 0.13.1",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -781,8 +781,8 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
- "synstructure 0.13.1",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -793,7 +793,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -818,7 +818,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-keyring",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
 ]
 
 [[package]]
@@ -922,7 +922,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-offchain",
  "sp-runtime 41.1.0",
  "sp-session",
@@ -932,7 +932,7 @@ dependencies = [
  "sp-weights",
  "staging-parachain-info",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "substrate-wasm-builder",
  "system-parachains-constants",
@@ -1059,7 +1059,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-offchain",
  "sp-runtime 41.1.0",
  "sp-session",
@@ -1069,7 +1069,7 @@ dependencies = [
  "sp-weights",
  "staging-parachain-info",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "substrate-wasm-builder",
  "system-parachains-constants",
@@ -1098,11 +1098,11 @@ dependencies = [
  "parachains-common",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-parachain-info",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "xcm-runtime-apis",
 ]
@@ -1125,7 +1125,7 @@ dependencies = [
  "sp-api 36.0.1",
  "sp-runtime 41.1.0",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "tracing",
 ]
@@ -1155,14 +1155,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
+ "pin-project-lite",
  "slab",
 ]
 
@@ -1269,7 +1270,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1323,13 +1324,13 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1344,16 +1345,16 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "instant",
  "rand 0.8.5",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line 0.24.2",
  "cfg-if",
@@ -1381,12 +1382,6 @@ name = "base58"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6107fe1be6682a68940da878d9e9f5e90ca5745b3dec9fd1bb393c8777d4f581"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1438,7 +1433,7 @@ dependencies = [
  "rand_core 0.6.4",
  "ripemd",
  "secp256k1 0.27.0",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -1581,9 +1576,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
@@ -1746,7 +1741,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-std",
 ]
 
@@ -1821,7 +1816,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-state-machine 0.45.0",
  "sp-std",
@@ -1863,7 +1858,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-std",
  "staging-xcm 16.1.0",
 ]
@@ -1897,7 +1892,7 @@ dependencies = [
  "sp-runtime 41.1.0",
  "sp-std",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
 ]
 
@@ -2025,7 +2020,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring",
  "sp-offchain",
  "sp-runtime 41.1.0",
@@ -2035,7 +2030,7 @@ dependencies = [
  "sp-version 39.0.0",
  "staging-parachain-info",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "substrate-wasm-builder",
  "system-parachains-constants",
@@ -2180,7 +2175,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring",
  "sp-offchain",
  "sp-runtime 41.1.0",
@@ -2190,7 +2185,7 @@ dependencies = [
  "sp-version 39.0.0",
  "staging-parachain-info",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "substrate-wasm-builder",
  "system-parachains-constants",
@@ -2231,13 +2226,13 @@ dependencies = [
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring",
  "sp-runtime 41.1.0",
  "sp-std",
  "sp-tracing",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
 ]
 
@@ -2264,7 +2259,7 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-std",
  "sp-trie 39.1.0",
@@ -2280,7 +2275,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
@@ -2313,9 +2308,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -2376,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "jobserver",
  "libc",
@@ -2471,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2499,15 +2494,14 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.10.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd94671561e36e4e7de75f753f577edafb0e7c05d6e4547229fdf7938fbcd2c3"
+checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
 dependencies = [
  "core2",
  "multibase",
- "multihash 0.18.1",
- "serde",
- "unsigned-varint 0.7.2",
+ "multihash 0.19.3",
+ "unsigned-varint 0.8.0",
 ]
 
 [[package]]
@@ -2532,9 +2526,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2542,9 +2536,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2561,7 +2555,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2692,7 +2686,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-offchain",
  "sp-runtime 41.1.0",
  "sp-session",
@@ -2701,7 +2695,7 @@ dependencies = [
  "sp-version 39.0.0",
  "staging-parachain-info",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "substrate-wasm-builder",
  "system-parachains-constants",
@@ -2790,7 +2784,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
@@ -2826,12 +2820,6 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
-name = "constcat"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
 
 [[package]]
 name = "convert_case"
@@ -2975,7 +2963,7 @@ dependencies = [
  "sp-version 39.0.0",
  "staging-parachain-info",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "substrate-wasm-builder",
  "system-parachains-constants",
@@ -3083,7 +3071,7 @@ dependencies = [
  "sp-version 39.0.0",
  "staging-parachain-info",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "substrate-wasm-builder",
  "system-parachains-constants",
@@ -3365,14 +3353,14 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-externalities",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-state-machine 0.45.0",
  "sp-std",
  "sp-trie 39.1.0",
  "sp-version 39.0.0",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "trie-db 0.30.0",
 ]
 
@@ -3385,7 +3373,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3413,7 +3401,7 @@ dependencies = [
  "frame-system 40.1.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-xcm 16.1.0",
 ]
@@ -3437,10 +3425,10 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
 ]
 
@@ -3511,7 +3499,7 @@ dependencies = [
  "polkadot-runtime-common",
  "sp-runtime 41.1.0",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
 ]
 
@@ -3553,14 +3541,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "cxx"
-version = "1.0.153"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4ab2681454aacfe7ce296ebc6df86791009f237f8020b0c752e8b245ba7c1d"
+checksum = "a71ea7f29c73f7ffa64c50b83c9fe4d3a6d4be89a86b009eb80d5a6d3429d741"
 dependencies = [
  "cc",
  "cxxbridge-cmd",
@@ -3572,47 +3560,47 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.153"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e431f7ba795550f2b11c32509b3b35927d899f0ad13a1d1e030a317a08facbe"
+checksum = "36a8232661d66dcf713394726157d3cfe0a89bfc85f52d6e9f9bbc2306797fe7"
 dependencies = [
  "cc",
  "codespan-reporting",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.153"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cbc41933767955d04c2a90151806029b93df5fd8b682ba22a967433347480a9"
+checksum = "4f44296c8693e9ea226a48f6a122727f77aa9e9e338380cb021accaeeb7ee279"
 dependencies = [
  "clap",
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.153"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9133547634329a5b76e5f58d1e53c16d627699bbcd421b9007796311165f9667"
+checksum = "c42f69c181c176981ae44ba9876e2ea41ce8e574c296b38d06925ce9214fb8e4"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.153"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e89d77ad5fd6066a3d42d94de3f72a2f23f95006da808177624429b5183596"
+checksum = "8faff5d4467e0709448187df29ccbf3b0982cc426ee444a193f87b11afb565a8"
 dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3636,7 +3624,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3647,20 +3635,20 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f9724adfcf41f45bf652b3995837669d73c4d49a1b5ac1ff82905ac7d9b5558"
+checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -3668,19 +3656,19 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e4fdb82bd54a12e42fb58a800dcae6b9e13982238ce2296dc3570b92148e1f"
+checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -3742,31 +3730,31 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "derive-where"
-version = "1.2.7"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.19"
+version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3795,7 +3783,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -3807,7 +3795,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -3891,7 +3879,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3915,9 +3903,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.100",
+ "syn 2.0.101",
  "termcolor",
- "toml 0.8.20",
+ "toml 0.8.22",
  "walkdir",
 ]
 
@@ -3963,7 +3951,7 @@ checksum = "7e8671d54058979a37a26f3511fbf8d198ba1aa35ffb202c42587d918d77213a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4007,7 +3995,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -4023,7 +4011,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "hex",
  "rand_core 0.6.4",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "zeroize",
 ]
 
@@ -4036,7 +4024,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4067,9 +4055,9 @@ dependencies = [
 
 [[package]]
 name = "emulated-integration-tests-common"
-version = "20.0.0"
+version = "20.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf3b3343225d64e2c7c9b4fd66795d9aa10d76c1e7e351cd4730944e4b84641"
+checksum = "22f1a377439a0fbba85ee130b57b044df03e8fefd51c8e731b29c73316391382"
 dependencies = [
  "asset-test-utils",
  "bp-messages",
@@ -4126,7 +4114,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4146,7 +4134,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4166,7 +4154,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4177,7 +4165,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4207,9 +4195,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -4295,7 +4283,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4499,7 +4487,7 @@ dependencies = [
  "sp-api 35.0.0",
  "sp-application-crypto 39.0.0",
  "sp-core 35.0.0",
- "sp-io 39.0.0",
+ "sp-io 39.0.1",
  "sp-runtime 40.1.0",
  "sp-runtime-interface",
  "sp-storage",
@@ -4524,7 +4512,7 @@ dependencies = [
  "sp-api 36.0.1",
  "sp-application-crypto 40.1.0",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-runtime-interface",
  "sp-storage",
@@ -4554,7 +4542,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4588,7 +4576,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-tracing",
 ]
@@ -4660,7 +4648,7 @@ dependencies = [
  "serde",
  "sp-core 36.1.0",
  "sp-crypto-hashing",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-state-machine 0.45.0",
  "spinners",
@@ -4700,7 +4688,7 @@ dependencies = [
  "sp-debug-derive",
  "sp-genesis-builder 0.16.0",
  "sp-inherents 35.0.0",
- "sp-io 39.0.0",
+ "sp-io 39.0.1",
  "sp-metadata-ir 0.8.0",
  "sp-runtime 40.1.0",
  "sp-staking 37.0.0",
@@ -4743,7 +4731,7 @@ dependencies = [
  "sp-debug-derive",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-metadata-ir 0.10.0",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
@@ -4773,7 +4761,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4794,7 +4782,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4807,7 +4795,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4818,7 +4806,7 @@ checksum = "ed971c6435503a099bdac99fe4c5bea08981709e5b5a0a8535a1856f48561191"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4835,7 +4823,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 35.0.0",
- "sp-io 39.0.0",
+ "sp-io 39.0.1",
  "sp-runtime 40.1.0",
  "sp-std",
  "sp-version 38.0.0",
@@ -4856,7 +4844,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-version 39.0.0",
  "sp-weights",
@@ -4995,7 +4983,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5005,7 +4993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.25",
+ "rustls 0.23.27",
  "rustls-pki-types",
 ]
 
@@ -5076,9 +5064,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5182,7 +5170,7 @@ dependencies = [
  "sp-version 39.0.0",
  "staging-parachain-info",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "substrate-wasm-builder",
  "system-parachains-constants",
@@ -5211,7 +5199,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5220,9 +5208,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5230,7 +5218,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -5280,9 +5268,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -5325,9 +5313,9 @@ checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex"
@@ -5454,17 +5442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hostname"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
-dependencies = [
- "cfg-if",
- "libc",
- "windows 0.52.0",
-]
-
-[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5577,7 +5554,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.10",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -5616,7 +5593,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rustls 0.23.25",
+ "rustls 0.23.27",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -5810,7 +5787,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5870,7 +5847,7 @@ dependencies = [
  "rtnetlink",
  "system-configuration",
  "tokio",
- "windows 0.53.0",
+ "windows",
 ]
 
 [[package]]
@@ -5958,7 +5935,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5993,12 +5970,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -6105,7 +6082,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.5.0",
+ "hermit-abi 0.5.1",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -6259,7 +6236,7 @@ dependencies = [
  "http 1.3.1",
  "jsonrpsee-core",
  "pin-project",
- "rustls 0.23.25",
+ "rustls 0.23.27",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "soketto",
@@ -6311,7 +6288,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "rustls 0.23.25",
+ "rustls 0.23.27",
  "rustls-platform-verifier",
  "serde",
  "serde_json",
@@ -6332,7 +6309,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6371,7 +6348,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6455,7 +6432,7 @@ dependencies = [
  "jsonpath-rust",
  "k8s-openapi",
  "kube-core",
- "pem 3.0.5",
+ "pem",
  "pin-project",
  "rand 0.8.5",
  "rustls 0.21.12",
@@ -6561,7 +6538,7 @@ dependencies = [
  "sp-runtime 41.1.0",
  "sp-trie 39.1.0",
  "sp-weights",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
 ]
 
 [[package]]
@@ -6597,15 +6574,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "a25169bd5913a4b437588a7e3d127cd6e90127b60e0ffbd834a38f1599e016b8"
 
 [[package]]
 name = "libp2p"
@@ -6617,7 +6594,7 @@ dependencies = [
  "either",
  "futures",
  "futures-timer",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libp2p-allow-block-list",
  "libp2p-connection-limits",
  "libp2p-core",
@@ -6735,9 +6712,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
+checksum = "fbb68ea10844211a59ce46230909fd0ea040e8a192454d4cc2ee0d53e12280eb"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -6745,8 +6722,8 @@ dependencies = [
  "multihash 0.19.3",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.8",
- "thiserror 1.0.69",
+ "sha2 0.10.9",
+ "thiserror 2.0.12",
  "tracing",
  "zeroize",
 ]
@@ -6771,7 +6748,7 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "rand 0.8.5",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 1.0.69",
  "tracing",
@@ -6836,7 +6813,7 @@ dependencies = [
  "once_cell",
  "quick-protobuf",
  "rand 0.8.5",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "snow",
  "static_assertions",
  "thiserror 1.0.69",
@@ -6880,7 +6857,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "ring 0.17.14",
- "rustls 0.23.25",
+ "rustls 0.23.27",
  "socket2",
  "thiserror 1.0.69",
  "tokio",
@@ -6940,7 +6917,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6970,9 +6947,9 @@ dependencies = [
  "futures-rustls",
  "libp2p-core",
  "libp2p-identity",
- "rcgen 0.11.3",
+ "rcgen",
  "ring 0.17.14",
- "rustls 0.23.25",
+ "rustls 0.23.27",
  "rustls-webpki 0.101.7",
  "thiserror 1.0.69",
  "x509-parser 0.16.0",
@@ -7039,7 +7016,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.10",
+ "redox_syscall 0.5.12",
 ]
 
 [[package]]
@@ -7137,9 +7114,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lioness"
@@ -7161,20 +7138,19 @@ checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "litep2p"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa3aa5628ae2b2283aa01dfa58947f1926aedba0160dd25041e2cd4bc71534c9"
+checksum = "d71056c23c896bb0e18113b2d2f1989be95135e6bdeedb0b757422ee21a073eb"
 dependencies = [
  "async-trait",
  "bs58",
  "bytes",
- "cid 0.10.1",
+ "cid 0.11.1",
  "ed25519-dalek",
  "futures",
  "futures-timer",
- "hex-literal",
  "hickory-resolver",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "libc",
  "mockall",
  "multiaddr 0.17.1",
@@ -7182,14 +7158,11 @@ dependencies = [
  "network-interface",
  "parking_lot 0.12.3",
  "pin-project",
- "prost 0.12.6",
+ "prost 0.13.5",
  "prost-build",
  "rand 0.8.5",
- "rcgen 0.10.0",
- "ring 0.16.20",
- "rustls 0.20.9",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "simple-dns",
  "smallvec",
  "snow",
@@ -7232,7 +7205,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -7261,7 +7234,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7273,7 +7246,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7287,7 +7260,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7298,7 +7271,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7309,7 +7282,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7419,9 +7392,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -7485,7 +7458,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7555,24 +7528,7 @@ dependencies = [
  "core2",
  "digest 0.10.7",
  "multihash-derive",
- "sha2 0.10.8",
- "sha3",
- "unsigned-varint 0.7.2",
-]
-
-[[package]]
-name = "multihash"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd8a792c1694c6da4f68db0a9d707c72bd260994da179e6030a5dcee00bb815"
-dependencies = [
- "blake2b_simd",
- "blake2s_simd",
- "blake3",
- "core2",
- "digest 0.10.7",
- "multihash-derive",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "unsigned-varint 0.7.2",
 ]
@@ -7719,9 +7675,9 @@ dependencies = [
 
 [[package]]
 name = "network-interface"
-version = "1.1.4"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a43439bf756eed340bdf8feba761e2d50c7d47175d87545cd5cbe4a137c4d1"
+checksum = "c3329f515506e4a2de3aa6e07027a6758e22e0f0e8eaf64fa47261cec2282602"
 dependencies = [
  "cc",
  "libc",
@@ -7817,7 +7773,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7935,9 +7891,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -7956,7 +7912,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7967,9 +7923,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
@@ -8015,7 +7971,7 @@ dependencies = [
  "scale-info",
  "sp-core 36.1.0",
  "sp-crypto-hashing",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8034,7 +7990,7 @@ dependencies = [
  "sp-api 35.0.0",
  "sp-arithmetic",
  "sp-core 35.0.0",
- "sp-io 39.0.0",
+ "sp-io 39.0.1",
  "sp-runtime 40.1.0",
 ]
 
@@ -8053,7 +8009,7 @@ dependencies = [
  "sp-api 36.0.1",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8102,7 +8058,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8188,7 +8144,7 @@ dependencies = [
  "sp-application-crypto 40.1.0",
  "sp-consensus-babe",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-session",
  "sp-staking 38.0.0",
@@ -8211,7 +8167,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-tracing",
 ]
@@ -8274,7 +8230,7 @@ dependencies = [
  "sp-api 36.0.1",
  "sp-consensus-beefy",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-state-machine 0.45.0",
 ]
@@ -8293,7 +8249,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8416,7 +8372,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8454,7 +8410,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8471,7 +8427,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8490,7 +8446,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8505,7 +8461,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
 ]
@@ -8527,7 +8483,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-npos-elections",
  "sp-runtime 41.1.0",
  "strum 0.26.3",
@@ -8561,7 +8517,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
 ]
@@ -8581,7 +8537,7 @@ dependencies = [
  "scale-info",
  "sp-core 36.1.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8602,7 +8558,7 @@ dependencies = [
  "sp-application-crypto 40.1.0",
  "sp-consensus-grandpa",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-session",
  "sp-staking 38.0.0",
@@ -8621,7 +8577,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8640,7 +8596,7 @@ dependencies = [
  "scale-info",
  "sp-application-crypto 40.1.0",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
 ]
@@ -8657,7 +8613,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8676,7 +8632,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-weights",
 ]
@@ -8697,7 +8653,7 @@ dependencies = [
  "polkadot-sdk-frame",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8757,7 +8713,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8795,7 +8751,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
  "sp-tracing",
@@ -8904,7 +8860,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8934,7 +8890,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8949,7 +8905,7 @@ dependencies = [
  "frame-system 40.1.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8968,7 +8924,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8987,7 +8943,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-state-machine 0.45.0",
  "sp-trie 39.1.0",
@@ -9000,7 +8956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "895fe6f50f621a69132697b8b43d29d1db4d9ff445eec410bf1fc98cd7e9412c"
 dependencies = [
  "alloy-core",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "environmental",
  "ethabi-decode",
  "ethereum-types",
@@ -9033,10 +8989,10 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "substrate-bn",
  "subxt-signer",
 ]
@@ -9052,8 +9008,8 @@ dependencies = [
  "pallet-revive-uapi",
  "polkavm-linker 0.21.0",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
- "toml 0.8.20",
+ "sp-io 40.0.1",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -9064,7 +9020,7 @@ checksum = "63c2dc2fc6961da23fefc54689ce81a8e006f6988bc465dcc9ab9db905d31766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9106,7 +9062,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-weights",
 ]
@@ -9125,7 +9081,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-session",
  "sp-staking 38.0.0",
@@ -9164,7 +9120,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "scale-info",
  "sp-arithmetic",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9186,7 +9142,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-application-crypto 40.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
 ]
@@ -9200,7 +9156,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9237,7 +9193,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9253,7 +9209,7 @@ dependencies = [
  "frame-system 40.1.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9271,7 +9227,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-storage",
  "sp-timestamp",
@@ -9290,7 +9246,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 35.0.0",
- "sp-io 39.0.0",
+ "sp-io 39.0.1",
  "sp-runtime 40.1.0",
 ]
 
@@ -9307,7 +9263,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9371,7 +9327,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -9416,10 +9372,10 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "tracing",
  "xcm-runtime-apis",
@@ -9436,10 +9392,10 @@ dependencies = [
  "frame-system 40.1.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
 ]
 
@@ -9462,7 +9418,7 @@ dependencies = [
  "sp-runtime 41.1.0",
  "sp-std",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
 ]
 
@@ -9483,7 +9439,7 @@ dependencies = [
  "sp-runtime 41.1.0",
  "sp-std",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
 ]
 
 [[package]]
@@ -9509,7 +9465,7 @@ dependencies = [
  "scale-info",
  "sp-consensus-aura",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-parachain-info",
  "staging-xcm 16.1.0",
@@ -9539,7 +9495,7 @@ dependencies = [
  "polkadot-parachain-primitives 16.1.0",
  "sp-consensus-aura",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-tracing",
  "staging-parachain-info",
@@ -9593,7 +9549,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9651,7 +9607,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.10",
+ "redox_syscall 0.5.12",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -9692,15 +9648,6 @@ dependencies = [
 
 [[package]]
 name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
-]
-
-[[package]]
-name = "pem"
 version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38af38e8470ac9dee3ce1bae1af9c1671fffc44ddfd8bd1d0a3445bf349a8ef3"
@@ -9727,9 +9674,9 @@ dependencies = [
 
 [[package]]
 name = "penpal-runtime"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6802ffad14b7ff3e000f115a7b96cff20305ba049d330854b255861d40efdc21"
+checksum = "9810e5fcb5b69bac72417f4bebb6883620e1ccccebedc36458b7c8108d5769e1"
 dependencies = [
  "assets-common",
  "cumulus-pallet-aura-ext",
@@ -9786,7 +9733,7 @@ dependencies = [
  "sp-version 39.0.0",
  "staging-parachain-info",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "substrate-wasm-builder",
  "testnet-parachains-constants",
@@ -9896,7 +9843,7 @@ dependencies = [
  "sp-version 39.0.0",
  "staging-parachain-info",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "substrate-wasm-builder",
  "system-parachains-constants",
@@ -10005,7 +9952,7 @@ dependencies = [
  "sp-version 39.0.0",
  "staging-parachain-info",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "substrate-wasm-builder",
  "system-parachains-constants",
@@ -10049,7 +9996,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10060,7 +10007,7 @@ checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -10070,7 +10017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
@@ -10090,7 +10037,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10191,7 +10138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d10a3da595ecd419e526a9cfcc013cd00bcd9a2c962991d6efb312df8307eaf"
 dependencies = [
  "bounded-collections",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "parity-scale-codec",
  "polkadot-core-primitives 16.0.0",
  "scale-info",
@@ -10208,7 +10155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72943c0948c686b47bacb1a03e59baff63bfba2e16e208d77f0f8615827f8564"
 dependencies = [
  "bounded-collections",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "parity-scale-codec",
  "polkadot-core-primitives 17.1.0",
  "scale-info",
@@ -10239,7 +10186,7 @@ dependencies = [
  "sp-consensus-slots",
  "sp-core 36.1.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keystore 0.42.0",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
@@ -10332,7 +10279,7 @@ dependencies = [
  "sp-debug-derive",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring",
  "sp-npos-elections",
  "sp-offchain",
@@ -10346,7 +10293,7 @@ dependencies = [
  "sp-version 39.0.0",
  "ss58-registry",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "substrate-wasm-builder",
  "tokio",
@@ -10392,14 +10339,14 @@ dependencies = [
  "sp-api 36.0.1",
  "sp-core 36.1.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring",
  "sp-npos-elections",
  "sp-runtime 41.1.0",
  "sp-session",
  "sp-staking 38.0.0",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "static_assertions",
 ]
@@ -10419,7 +10366,7 @@ dependencies = [
  "sp-runtime 41.1.0",
  "sp-trie 39.1.0",
  "sp-weights",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
 ]
 
 [[package]]
@@ -10472,7 +10419,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core 36.1.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keystore 0.42.0",
  "sp-runtime 41.1.0",
  "sp-session",
@@ -10519,7 +10466,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring",
  "sp-offchain",
  "sp-runtime 41.1.0",
@@ -10650,7 +10597,7 @@ dependencies = [
  "polkavm-common 0.9.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10662,7 +10609,7 @@ dependencies = [
  "polkavm-common 0.18.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10674,7 +10621,7 @@ dependencies = [
  "polkavm-common 0.21.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10684,7 +10631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl 0.9.0",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10694,7 +10641,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c16669ddc7433e34c1007d31080b80901e3e8e523cb9d4b441c3910cf9294b"
 dependencies = [
  "polkavm-derive-impl 0.18.1",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10704,7 +10651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36837f6b7edfd6f4498f8d25d81da16cf03bd6992c3e56f3d477dfc90f4fefca"
 dependencies = [
  "polkavm-derive-impl 0.21.0",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10807,7 +10754,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -10838,12 +10785,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10936,7 +10883,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10947,14 +10894,14 @@ checksum = "75eea531cfcd120e0851a3f8aed42c4841f78c889eefafd96339c72677ae42c3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -10993,7 +10940,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11052,7 +10999,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types",
  "regex",
- "syn 2.0.100",
+ "syn 2.0.101",
  "tempfile",
 ]
 
@@ -11066,7 +11013,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11079,7 +11026,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11093,9 +11040,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
  "cc",
 ]
@@ -11141,7 +11088,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.25",
+ "rustls 0.23.27",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -11151,16 +11098,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
+checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ring 0.17.14",
  "rustc-hash 2.1.1",
- "rustls 0.23.25",
+ "rustls 0.23.27",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -11171,9 +11118,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -11218,13 +11165,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -11253,7 +11199,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -11321,23 +11267,11 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbe84efe2f38dea12e9bfc1f65377fdf03e53a18cb3b995faedf7934c7e785b"
-dependencies = [
- "pem 1.1.1",
- "ring 0.16.20",
- "time",
- "yasna",
-]
-
-[[package]]
-name = "rcgen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c4f3084aa3bc7dfbba4eff4fab2a54db4324965d8872ab933565e6fbd83bc6"
 dependencies = [
- "pem 3.0.5",
+ "pem",
  "ring 0.16.20",
  "time",
  "yasna",
@@ -11354,9 +11288,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -11367,7 +11301,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -11389,7 +11323,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11484,7 +11418,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.8",
+ "h2 0.4.10",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -11519,12 +11453,9 @@ dependencies = [
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48375394603e3dd4b2d64371f7148fd8c7baa2680e28741f2cb8d23b59e3d4c4"
-dependencies = [
- "hostname",
-]
+checksum = "fc7c8f7f733062b66dc1c63f9db168ac0b97a9210e247fa90fdc9ad08f51b302"
 
 [[package]]
 name = "rfc6979"
@@ -11559,7 +11490,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
@@ -11608,7 +11539,7 @@ dependencies = [
  "sp-runtime 41.1.0",
  "sp-weights",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
 ]
 
 [[package]]
@@ -11648,7 +11579,7 @@ dependencies = [
  "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.0",
+ "rand 0.9.1",
  "rlp 0.5.2",
  "ruint-macro",
  "serde",
@@ -11742,26 +11673,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b80e3dec595989ea8510028f30c408a4630db12c9cbb8de34203b89d6577e99"
-dependencies = [
- "ring 0.16.20",
- "sct",
- "webpki",
 ]
 
 [[package]]
@@ -11778,15 +11698,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "log",
  "once_cell",
  "ring 0.17.14",
  "rustls-pki-types",
- "rustls-webpki 0.103.1",
+ "rustls-webpki 0.103.2",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -11844,22 +11764,22 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5467026f437b4cb2a533865eaa73eb840019a0916f4b9ec563c6e617e086c9"
+checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
 dependencies = [
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.25",
+ "rustls 0.23.27",
  "rustls-native-certs 0.8.1",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.1",
+ "rustls-webpki 0.103.2",
  "security-framework 3.2.0",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
 ]
 
@@ -11881,9 +11801,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types",
@@ -11915,7 +11835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
 dependencies = [
  "byteorder",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
 ]
 
 [[package]]
@@ -12011,7 +11931,7 @@ dependencies = [
  "sp-core 36.1.0",
  "sp-crypto-hashing",
  "sp-genesis-builder 0.17.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-state-machine 0.45.0",
  "sp-tracing",
@@ -12026,7 +11946,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12140,7 +12060,7 @@ dependencies = [
  "sp-api 36.0.1",
  "sp-core 36.1.0",
  "sp-externalities",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-panic-handler",
  "sp-runtime-interface",
  "sp-trie 39.1.0",
@@ -12223,9 +12143,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.49.0"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4601296dddbaee7cb7eaf5709bbd24a56bba470d8b8cbadaad77496fe70a7706"
+checksum = "df65eb7a3c4c141de3f14b12a9832c75c7ada1fd580b0bc440263cb8ca2c5b77"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -12408,7 +12328,7 @@ checksum = "55feca303d4ba839f02261c9a73d40f6b0ac7523882b4008472922b934678729"
 dependencies = [
  "async-trait",
  "futures",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "log",
  "parity-scale-codec",
  "serde",
@@ -12451,7 +12371,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
 dependencies = [
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "parity-scale-codec",
  "scale-bits",
  "scale-type-resolver",
@@ -12482,7 +12402,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12510,7 +12430,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12536,7 +12456,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12558,7 +12478,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "syn 2.0.100",
+ "syn 2.0.101",
  "thiserror 1.0.69",
 ]
 
@@ -12616,7 +12536,7 @@ dependencies = [
  "merlin",
  "rand_core 0.6.4",
  "serde_bytes",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -12642,7 +12562,7 @@ dependencies = [
  "password-hash",
  "pbkdf2",
  "salsa20",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -12874,7 +12794,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12916,7 +12836,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "ryu",
  "serde",
@@ -12959,9 +12879,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -13005,9 +12925,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -13085,9 +13005,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smol"
@@ -13121,7 +13041,7 @@ dependencies = [
  "bs58",
  "chacha20",
  "crossbeam-queue",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "ed25519-zebra",
  "either",
  "event-listener 5.4.0",
@@ -13148,7 +13068,7 @@ dependencies = [
  "schnorrkel",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "siphasher",
  "slab",
@@ -13171,7 +13091,7 @@ dependencies = [
  "base64 0.22.1",
  "blake2-rfc",
  "bs58",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "either",
  "event-listener 5.4.0",
  "fnv",
@@ -13209,7 +13129,7 @@ dependencies = [
  "rand_core 0.6.4",
  "ring 0.17.14",
  "rustc_version 0.4.1",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle 2.6.1",
 ]
 
@@ -13239,7 +13159,7 @@ dependencies = [
  "snowbridge-ethereum 0.11.0",
  "snowbridge-milagro-bls",
  "sp-core 35.0.0",
- "sp-io 39.0.0",
+ "sp-io 39.0.1",
  "sp-runtime 40.1.0",
  "sp-std",
  "ssz_rs",
@@ -13262,7 +13182,7 @@ dependencies = [
  "snowbridge-ethereum 0.12.0",
  "snowbridge-milagro-bls",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-std",
  "ssz_rs",
@@ -13271,9 +13191,9 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-core"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07532aa025be78022c70c54fdefa7df87495d11661d2bcb09533a2a68a99d1a"
+checksum = "eef820f3efa2114c2e12518c7b346de0df83e59dee2aa08cf7097594aef62a9f"
 dependencies = [
  "ethabi-decode",
  "frame-support 39.1.0",
@@ -13286,11 +13206,11 @@ dependencies = [
  "snowbridge-beacon-primitives 0.12.1",
  "sp-arithmetic",
  "sp-core 35.0.0",
- "sp-io 39.0.0",
+ "sp-io 39.0.1",
  "sp-runtime 40.1.0",
  "sp-std",
  "staging-xcm 15.0.3",
- "staging-xcm-builder 18.1.0",
+ "staging-xcm-builder 18.2.0",
 ]
 
 [[package]]
@@ -13311,11 +13231,11 @@ dependencies = [
  "serde",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-std",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
 ]
 
@@ -13335,7 +13255,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde-big-array",
- "sp-io 39.0.0",
+ "sp-io 39.0.1",
  "sp-runtime 40.1.0",
  "sp-std",
 ]
@@ -13356,7 +13276,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde-big-array",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-std",
 ]
@@ -13378,11 +13298,11 @@ dependencies = [
  "snowbridge-core 0.13.1",
  "snowbridge-verification-primitives",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-std",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
 ]
 
@@ -13415,9 +13335,9 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-outbound-queue-primitives"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15dff51274b7d49803c0608c59af1ecc32ab79cf97d3d200d18a233102c992a6"
+checksum = "0f2bfcb100960537854629e31cdbe4e553854e27489c59c8d784aba073b0c86e"
 dependencies = [
  "alloy-core",
  "ethabi-decode",
@@ -13432,11 +13352,11 @@ dependencies = [
  "snowbridge-verification-primitives",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-std",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
 ]
 
@@ -13476,7 +13396,7 @@ dependencies = [
  "snowbridge-pallet-ethereum-client-fixtures",
  "snowbridge-verification-primitives",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-std",
  "static_assertions",
@@ -13484,9 +13404,9 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-pallet-ethereum-client-fixtures"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d245d9b442609c0c373ffc914ade31ce17392030cc30694d1ae3e2446f9324a"
+checksum = "6f8a0d642afa0c47145729267da0aff53b11c9197034a95907b7795b005110dc"
 dependencies = [
  "hex-literal",
  "snowbridge-beacon-primitives 0.13.1",
@@ -13517,7 +13437,7 @@ dependencies = [
  "snowbridge-inbound-queue-primitives",
  "snowbridge-pallet-inbound-queue-fixtures",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-std",
  "staging-xcm 16.1.0",
@@ -13557,16 +13477,16 @@ dependencies = [
  "snowbridge-outbound-queue-primitives",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-std",
 ]
 
 [[package]]
 name = "snowbridge-pallet-system"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597a3469ef25ee4579a184f40e4c0bbcdd7c29a7736a7ffd4a8fd6d03531e63"
+checksum = "4089d40c9657203591fa78186d719ccedfe535d4202ce641dfa9ce76b61ca085"
 dependencies = [
  "frame-benchmarking 40.0.0",
  "frame-support 40.1.0",
@@ -13577,7 +13497,7 @@ dependencies = [
  "snowbridge-core 0.13.1",
  "snowbridge-outbound-queue-primitives",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-std",
  "staging-xcm 16.1.0",
@@ -13595,9 +13515,9 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "snowbridge-core 0.12.1",
+ "snowbridge-core 0.12.2",
  "sp-core 35.0.0",
- "sp-io 39.0.0",
+ "sp-io 39.0.1",
  "sp-runtime 40.1.0",
  "sp-std",
  "staging-xcm 15.0.3",
@@ -13620,7 +13540,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-std",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
 ]
 
@@ -13648,7 +13568,7 @@ dependencies = [
  "snowbridge-pallet-outbound-queue",
  "snowbridge-pallet-system",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring",
  "sp-runtime 41.1.0",
  "staging-parachain-info",
@@ -13766,7 +13686,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13781,7 +13701,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13794,7 +13714,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 35.0.0",
- "sp-io 39.0.0",
+ "sp-io 39.0.1",
 ]
 
 [[package]]
@@ -13807,7 +13727,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
 ]
 
 [[package]]
@@ -13933,7 +13853,7 @@ dependencies = [
  "sp-application-crypto 40.1.0",
  "sp-core 36.1.0",
  "sp-crypto-hashing",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keystore 0.42.0",
  "sp-mmr-primitives",
  "sp-runtime 41.1.0",
@@ -14075,7 +13995,7 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "digest 0.10.7",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "twox-hash",
 ]
@@ -14088,7 +14008,7 @@ checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -14109,7 +14029,7 @@ checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -14179,9 +14099,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "39.0.0"
+version = "39.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86554fd101635b388e41ce83c28754ee30078e6a93480e1310914b4b09a67130"
+checksum = "594a1c12ec7a1514caa878c2370902d116e6d7606a449c805bc91a4e62ef1ecf"
 dependencies = [
  "bytes",
  "docify",
@@ -14206,9 +14126,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "40.0.0"
+version = "40.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5d93ea3512cf361577719bab161e46eb04d3abd8563e32bdf5df4a42aea0ba"
+checksum = "3e41d010bcc515d119901ff7ac83150c335d543c7f6c03be5c8fe08430b8a03b"
 dependencies = [
  "bytes",
  "docify",
@@ -14396,7 +14316,7 @@ dependencies = [
  "sp-application-crypto 39.0.0",
  "sp-arithmetic",
  "sp-core 35.0.0",
- "sp-io 39.0.0",
+ "sp-io 39.0.1",
  "sp-std",
  "sp-trie 38.0.0",
  "sp-weights",
@@ -14426,7 +14346,7 @@ dependencies = [
  "sp-application-crypto 40.1.0",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-std",
  "sp-trie 39.1.0",
  "sp-weights",
@@ -14465,7 +14385,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -14699,7 +14619,7 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -14891,7 +14811,7 @@ dependencies = [
  "sp-debug-derive",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-keyring",
  "sp-npos-elections",
  "sp-offchain",
@@ -14905,7 +14825,7 @@ dependencies = [
  "sp-version 39.0.0",
  "ss58-registry",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "staging-xcm-executor 19.1.0",
  "substrate-wasm-builder",
  "tokio",
@@ -14972,9 +14892,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "18.1.0"
+version = "18.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a294dac930786c5d2b4c2113dc8891dd5095bf0e04537e0262206e09726b0ff1"
+checksum = "bb41713b55123a0ec0d2690899cce5cd7354217455650f3bc80c75dd39ad8f02"
 dependencies = [
  "frame-support 39.1.0",
  "frame-system 39.1.0",
@@ -14986,7 +14906,7 @@ dependencies = [
  "polkadot-parachain-primitives 15.0.0",
  "scale-info",
  "sp-arithmetic",
- "sp-io 39.0.0",
+ "sp-io 39.0.1",
  "sp-runtime 40.1.0",
  "sp-weights",
  "staging-xcm 15.0.3",
@@ -14995,9 +14915,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "20.0.0"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e041eaa60fc0df3dbaa5779959f5eaac9c1b81d045a5a1792479e46dfd31f028"
+checksum = "3fdd44a74a38339c423f690900678a1b5a31d0a44d8e01a0f445a64c96ec3175"
 dependencies = [
  "environmental",
  "frame-support 40.1.0",
@@ -15010,7 +14930,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-weights",
  "staging-xcm 16.1.0",
@@ -15032,7 +14952,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 35.0.0",
- "sp-io 39.0.0",
+ "sp-io 39.0.1",
  "sp-runtime 40.1.0",
  "sp-weights",
  "staging-xcm 15.0.3",
@@ -15053,7 +14973,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-weights",
  "staging-xcm 16.1.0",
@@ -15123,7 +15043,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15135,7 +15055,7 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
  "schnorrkel",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "zeroize",
 ]
 
@@ -15183,9 +15103,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "26.0.0"
+version = "26.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e681dd525b728263041cde9acdd07fa1c4d9f184c9b269a1c9df26e8401dae67"
+checksum = "1adc17ecd661e16b25708f36f6e6961f809a3ab16c89132a4acd7936c0f31e46"
 dependencies = [
  "array-bytes",
  "build-helper",
@@ -15201,13 +15121,13 @@ dependencies = [
  "sc-executor",
  "shlex",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-maybe-compressed-blob",
  "sp-tracing",
  "sp-version 39.0.0",
  "strum 0.26.3",
  "tempfile",
- "toml 0.8.20",
+ "toml 0.8.22",
  "walkdir",
  "wasm-opt",
 ]
@@ -15274,7 +15194,7 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata",
- "syn 2.0.100",
+ "syn 2.0.101",
  "thiserror 1.0.69",
 ]
 
@@ -15337,7 +15257,7 @@ dependencies = [
  "scale-typegen",
  "subxt-codegen",
  "subxt-utils-fetchmetadata",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15378,7 +15298,7 @@ dependencies = [
  "secrecy 0.10.3",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subxt-core",
  "zeroize",
 ]
@@ -15407,9 +15327,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -15425,7 +15345,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15451,13 +15371,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15529,7 +15449,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -15590,7 +15510,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15601,7 +15521,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15681,9 +15601,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -15715,7 +15635,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15755,7 +15675,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.25",
+ "rustls 0.23.27",
  "tokio",
 ]
 
@@ -15790,7 +15710,7 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.25",
+ "rustls 0.23.27",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -15800,9 +15720,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -15824,9 +15744,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -15836,25 +15756,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tower"
@@ -15941,7 +15868,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -16059,8 +15986,8 @@ dependencies = [
  "http 1.3.1",
  "httparse",
  "log",
- "rand 0.9.0",
- "rustls 0.23.25",
+ "rand 0.9.1",
+ "rustls 0.23.27",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.12",
@@ -16276,9 +16203,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "w3f-bls"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a3028804c8bbae2a97a15b71ffc0e308c4b01a520994aafa77d56e94e19024"
+checksum = "e6bfb937b3d12077654a9e43e32a4e9c20177dd9fea0f3aba673e7840bb54f32"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381 0.4.0",
@@ -16287,14 +16214,12 @@ dependencies = [
  "ark-serialize 0.4.2",
  "ark-serialize-derive 0.4.2",
  "arrayref",
- "constcat",
  "digest 0.10.7",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
- "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -16409,7 +16334,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -16444,7 +16369,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -16632,7 +16557,7 @@ dependencies = [
  "log",
  "rustix 0.36.17",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "toml 0.5.11",
  "windows-sys 0.45.0",
  "zstd 0.11.2+zstd.1.5.2",
@@ -16797,20 +16722,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.4"
+name = "webpki-root-certs"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "ring 0.17.14",
- "untrusted 0.9.0",
+ "webpki-root-certs 1.0.0",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
+checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -16835,7 +16759,7 @@ dependencies = [
  "sp-runtime 41.1.0",
  "sp-weights",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
 ]
 
 [[package]]
@@ -16887,30 +16811,11 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
 dependencies = [
  "windows-core 0.53.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
-dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -16945,7 +16850,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -16956,7 +16861,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -17292,9 +17197,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
 dependencies = [
  "memchr",
 ]
@@ -17392,14 +17297,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix 1.0.5",
+ "rustix 1.0.7",
 ]
 
 [[package]]
 name = "xcm-emulator"
-version = "0.19.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a344f7ea40a3c685b99c34220c0863bd9d5add4f534ff89493063d2fc235c5a9"
+checksum = "42dca9b3d5697a871f9c2d54f3c97a7a311dd9a885d47a358a5383a1b6ca8b58"
 dependencies = [
  "array-bytes",
  "cumulus-pallet-parachain-system",
@@ -17412,6 +17317,7 @@ dependencies = [
  "log",
  "pallet-balances",
  "pallet-message-queue",
+ "pallet-timestamp",
  "parachains-common",
  "parity-scale-codec",
  "paste",
@@ -17421,7 +17327,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core 36.1.0",
  "sp-crypto-hashing",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-tracing",
  "staging-xcm 16.1.0",
@@ -17437,7 +17343,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -17457,9 +17363,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "xmltree"
@@ -17536,8 +17442,8 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
- "synstructure 0.13.1",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -17551,11 +17457,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -17566,18 +17472,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -17597,8 +17503,8 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
- "synstructure 0.13.1",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -17618,7 +17524,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -17640,14 +17546,14 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zombienet-configuration"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23f5abe2a83faf76fe4d6c2243c495bd7fd75c3b1a66657e99db173b7418839"
+checksum = "5ead0cab80f2225376a428b2e8d89f475effa79b39ad5afed991020c8a4a2297"
 dependencies = [
  "anyhow",
  "lazy_static",
@@ -17658,7 +17564,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "toml 0.8.20",
+ "toml 0.8.22",
  "tracing",
  "url",
  "zombienet-support",
@@ -17666,9 +17572,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-orchestrator"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b882fa555eddda618be464ea2ce47de4e4e9142581eced19de4b12d0ace3198"
+checksum = "a15eb932d7400101589147d50d6415f53bae8f2c5ebf17b70d558cdfd838b878"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -17683,7 +17589,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sp-core 35.0.0",
  "subxt",
  "subxt-signer",
@@ -17699,9 +17605,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-prom-metrics-parser"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca98a24687ebd7fc06872ef872f1be8c003bd0d20f285091f45c24e9bec9973"
+checksum = "f6d8692f36907a2529f61ed38ccc09bc107fde88272ebc6297d3e4ab4c344278"
 dependencies = [
  "pest",
  "pest_derive",
@@ -17710,9 +17616,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-provider"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c65a3e3e07ab327e54be1668272ef2575a9c54aa4beb0d1e453df5046073772"
+checksum = "584a368c7efb0af573016aa21bdbfa21e262096a627d65b5c2a17779b0fc68e3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -17727,7 +17633,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tar",
  "thiserror 1.0.69",
  "tokio",
@@ -17741,9 +17647,9 @@ dependencies = [
 
 [[package]]
 name = "zombienet-sdk"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8ece725021717cc70b7f35c9f95819d03fd7818a596560c4d02dda8731f25e3"
+checksum = "9bd2ee69d116b73983edc84a93667beb2e0db3520fc7679dc24b66e005545e86"
 dependencies = [
  "async-trait",
  "futures",
@@ -17771,17 +17677,19 @@ dependencies = [
 
 [[package]]
 name = "zombienet-support"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42dcf18237dbd576d7696e331085222c144e89ebe71b462f616a9147f8162bb"
+checksum = "0e2f73e8ce47e5745ef9ee6b0cf58d7c3bbf77049d5561e1ad328f7248014e31"
 dependencies = [
  "anyhow",
  "async-trait",
  "futures",
+ "lazy_static",
  "nix 0.29.0",
  "rand 0.8.5",
  "regex",
  "reqwest",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,6 +2159,8 @@ dependencies = [
  "serde_json",
  "snowbridge-beacon-primitives 0.13.1",
  "snowbridge-core 0.13.1",
+ "snowbridge-merkle-tree",
+ "snowbridge-outbound-queue-primitives",
  "snowbridge-outbound-queue-runtime-api",
  "snowbridge-pallet-ethereum-client",
  "snowbridge-pallet-ethereum-client-fixtures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ cumulus-pallet-xcmp-queue = { version = "0.20.0", default-features = false }
 cumulus-primitives-aura = { version = "0.17.0", default-features = false }
 cumulus-primitives-core = { version = "0.18.1", default-features = false }
 cumulus-primitives-utility = { version = "0.20.0", default-features = false }
-emulated-integration-tests-common = { version = "20.0.0" }
+emulated-integration-tests-common = { version = "20.0.1" }
 #encointer-balances-tx-payment = { version = "~15.1.0", default-features = false }
 #encointer-balances-tx-payment-rpc-runtime-api = { version = "~15.1.0", default-features = false }
 #encointer-kusama-runtime = { path = "system-parachains/encointer" }
@@ -175,7 +175,7 @@ parachains-common = { version = "21.0.0", default-features = false }
 parachains-runtimes-test-utils = { version = "22.0.0" }
 paste = { version = "1.0.14" }
 penpal-emulated-chain = { path = "integration-tests/emulated/chains/parachains/testing/penpal" }
-penpal-runtime = { version = "0.28.0" }
+penpal-runtime = { version = "0.28.1" }
 people-kusama-emulated-chain = { path = "integration-tests/emulated/chains/parachains/people/people-kusama" }
 people-kusama-runtime = { path = "system-parachains/people/people-kusama" }
 people-polkadot-emulated-chain = { path = "integration-tests/emulated/chains/parachains/people/people-polkadot" }
@@ -193,7 +193,7 @@ frame-metadata-hash-extension = { version = "0.8.0", default-features = false }
 remote-externalities = { version = "0.50.0", package = "frame-remote-externalities" }
 runtime-parachains = { version = "19.1.0", default-features = false, package = "polkadot-runtime-parachains" }
 sc-chain-spec = { version = "42.0.0" }
-sc-network = { version = "0.49.0" }
+sc-network = { version = "0.49.1" }
 scale-info = { version = "2.10.0", default-features = false }
 separator = { version = "0.4.1" }
 serde = { version = "1.0.196" }
@@ -205,9 +205,9 @@ snowbridge-outbound-queue-runtime-api = { version = "0.13.0", default-features =
 snowbridge-pallet-ethereum-client = { version = "0.13.0", default-features = false }
 snowbridge-pallet-inbound-queue = { version = "0.13.1", default-features = false }
 snowbridge-pallet-inbound-queue-fixtures = { version = "0.21.0" }
-snowbridge-pallet-ethereum-client-fixtures = { version = "0.21.0" }
+snowbridge-pallet-ethereum-client-fixtures = { version = "0.21.1" }
 snowbridge-pallet-outbound-queue = { version = "0.13.0", default-features = false }
-snowbridge-pallet-system = { version = "0.13.1", default-features = false }
+snowbridge-pallet-system = { version = "0.13.2", default-features = false }
 snowbridge-router-primitives = { version = "0.18.1", default-features = false }
 snowbridge-runtime-common = { version = "0.13.0", default-features = false }
 snowbridge-runtime-test-common = { version = "0.15.0" }
@@ -221,7 +221,7 @@ sp-core = { version = "36.1.0", default-features = false }
 sp-debug-derive = { version = "14.0.0", default-features = false }
 sp-genesis-builder = { version = "0.17.0", default-features = false }
 sp-inherents = { version = "36.0.0", default-features = false }
-sp-io = { version = "40.0.0", default-features = false }
+sp-io = { version = "40.0.1", default-features = false }
 sp-keyring = { version = "41.0.0" }
 sp-npos-elections = { version = "36.1.0", default-features = false }
 sp-offchain = { version = "36.0.0", default-features = false }
@@ -236,12 +236,12 @@ sp-transaction-pool = { version = "36.0.0", default-features = false }
 sp-trie = { version = "39.1.0", default-features = false }
 sp-version = { version = "39.0.0", default-features = false }
 sp-weights = { version = "31.1.0", default-features = false }
-substrate-wasm-builder = { version = "26.0.0" }
+substrate-wasm-builder = { version = "26.0.1" }
 system-parachains-constants = { path = "system-parachains/constants", default-features = false }
 tokio = { version = "1.36.0" }
 xcm = { version = "16.1.0", default-features = false, package = "staging-xcm" }
-xcm-builder = { version = "20.0.0", default-features = false, package = "staging-xcm-builder" }
-xcm-emulator = { version = "0.19.0" }
+xcm-builder = { version = "20.1.0", default-features = false, package = "staging-xcm-builder" }
+xcm-emulator = { version = "0.19.1" }
 xcm-executor = { version = "19.1.0", default-features = false, package = "staging-xcm-executor" }
 xcm-runtime-apis = { version = "0.7.0", default-features = false }
 anyhow = { version = "1.0.82" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,9 @@ serde_json = { version = "1.0.113", default-features = false }
 smallvec = { version = "1.13.1" }
 snowbridge-beacon-primitives = { version = "0.13.1", default-features = false }
 snowbridge-core = { version = "0.13.1", default-features = false }
+snowbridge-merkle-tree = { version = "0.2.0", default-features = false }
 snowbridge-outbound-queue-runtime-api = { version = "0.13.0", default-features = false }
+snowbridge-outbound-queue-primitives = { version = "0.2.1", default-features = false }
 snowbridge-pallet-ethereum-client = { version = "0.13.0", default-features = false }
 snowbridge-pallet-inbound-queue = { version = "0.13.1", default-features = false }
 snowbridge-pallet-inbound-queue-fixtures = { version = "0.21.0" }

--- a/integration-tests/emulated/chains/parachains/assets/asset-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/assets/asset-hub-kusama/Cargo.toml
@@ -42,4 +42,5 @@ runtime-benchmarks = [
 	"penpal-emulated-chain/runtime-benchmarks",
 	"polkadot-parachain-primitives/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/chains/parachains/assets/asset-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/assets/asset-hub-polkadot/Cargo.toml
@@ -43,4 +43,5 @@ runtime-benchmarks = [
 	"polkadot-emulated-chain/runtime-benchmarks",
 	"polkadot-parachain-primitives/runtime-benchmarks",
 	"snowbridge-router-primitives/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/chains/parachains/bridges/bridge-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/bridges/bridge-hub-kusama/Cargo.toml
@@ -32,4 +32,5 @@ runtime-benchmarks = [
 	"bridge-hub-kusama-runtime/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"parachains-common/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/chains/parachains/bridges/bridge-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/bridges/bridge-hub-polkadot/Cargo.toml
@@ -32,4 +32,5 @@ runtime-benchmarks = [
 	"bridge-hub-polkadot-runtime/runtime-benchmarks",
 	"frame-support/runtime-benchmarks",
 	"parachains-common/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/chains/parachains/testing/penpal/Cargo.toml
+++ b/integration-tests/emulated/chains/parachains/testing/penpal/Cargo.toml
@@ -33,4 +33,5 @@ runtime-benchmarks = [
 	"parachains-common/runtime-benchmarks",
 	"penpal-runtime/runtime-benchmarks",
 	"polkadot-emulated-chain/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/helpers/Cargo.toml
+++ b/integration-tests/emulated/helpers/Cargo.toml
@@ -32,4 +32,5 @@ runtime-benchmarks = [
 	"pallet-balances/runtime-benchmarks",
 	"pallet-message-queue/runtime-benchmarks",
 	"pallet-xcm/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/Cargo.toml
@@ -64,4 +64,5 @@ runtime-benchmarks = [
 	"system-parachains-constants/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/Cargo.toml
@@ -63,4 +63,5 @@ runtime-benchmarks = [
 	"system-parachains-constants/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/Cargo.toml
@@ -77,4 +77,5 @@ runtime-benchmarks = [
 	"system-parachains-constants/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/Cargo.toml
@@ -79,4 +79,5 @@ runtime-benchmarks = [
 	"system-parachains-constants/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/tests/collectives/collectives-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/collectives/collectives-polkadot/Cargo.toml
@@ -72,4 +72,5 @@ runtime-benchmarks = [
 	"system-parachains-constants/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/tests/coretime/coretime-kusama/Cargo.toml
+++ b/integration-tests/emulated/tests/coretime/coretime-kusama/Cargo.toml
@@ -59,4 +59,5 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/tests/coretime/coretime-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/coretime/coretime-polkadot/Cargo.toml
@@ -57,4 +57,5 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/tests/people/people-kusama/Cargo.toml
+++ b/integration-tests/emulated/tests/people/people-kusama/Cargo.toml
@@ -55,4 +55,5 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/integration-tests/emulated/tests/people/people-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/people/people-polkadot/Cargo.toml
@@ -55,4 +55,5 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/relay/kusama/Cargo.toml
+++ b/relay/kusama/Cargo.toml
@@ -274,6 +274,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-election-provider-support/try-runtime",

--- a/relay/kusama/src/governance/mod.rs
+++ b/relay/kusama/src/governance/mod.rs
@@ -48,6 +48,7 @@ impl pallet_conviction_voting::Config for Runtime {
 		frame_support::traits::tokens::currency::ActiveIssuanceOf<Balances, Self::AccountId>;
 	type Polls = Referenda;
 	type BlockNumberProvider = System;
+	type VotingHooks = ();
 }
 
 parameter_types! {

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -1520,7 +1520,6 @@ impl Get<InteriorLocation> for BrokerPot {
 impl coretime::Config for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
 	type BrokerId = BrokerId;
 	type WeightInfo = weights::runtime_parachains_coretime::WeightInfo<Runtime>;
 	type SendXcm = crate::xcm_config::XcmRouter;
@@ -1731,8 +1730,7 @@ impl pallet_nomination_pools::Config for Runtime {
 	type PalletId = PoolsPalletId;
 	type MaxPointsToBalance = MaxPointsToBalance;
 	type AdminOrigin = EitherOf<EnsureRoot<AccountId>, StakingAdmin>;
-	// TODO: this will come back later (stable25XY)
-	// type Filter = pallet_staking::AllStakers<Runtime>;
+	type Filter = pallet_staking::AllStakers<Runtime>;
 	type BlockNumberProvider = System;
 }
 

--- a/relay/kusama/src/xcm_config.rs
+++ b/relay/kusama/src/xcm_config.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use frame_support::{
 	parameter_types,
-	traits::{Contains, Equals, Everything, Nothing},
+	traits::{Contains, Disabled, Equals, Everything, Nothing},
 };
 use frame_system::EnsureRoot;
 use kusama_runtime_constants::{currency::CENTS, system_parachain::*};
@@ -226,6 +226,7 @@ impl xcm_executor::Config for XcmConfig {
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
+	type XcmEventEmitter = XcmPallet;
 }
 
 parameter_types! {
@@ -304,4 +305,6 @@ impl pallet_xcm::Config for Runtime {
 	type RemoteLockConsumerIdentifier = ();
 	type WeightInfo = crate::weights::pallet_xcm::WeightInfo<Runtime>;
 	type AdminOrigin = EnsureRoot<AccountId>;
+	// Aliasing is disabled: xcm_executor::Config::Aliasers allows `Nothing`.
+	type AuthorizedAliasConsideration = Disabled;
 }

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -274,6 +274,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]
 try-runtime = [
 	"frame-election-provider-support/try-runtime",

--- a/relay/polkadot/src/governance/mod.rs
+++ b/relay/polkadot/src/governance/mod.rs
@@ -45,6 +45,7 @@ impl pallet_conviction_voting::Config for Runtime {
 		frame_support::traits::tokens::currency::ActiveIssuanceOf<Balances, Self::AccountId>;
 	type Polls = Referenda;
 	type BlockNumberProvider = System;
+	type VotingHooks = ();
 }
 
 parameter_types! {

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -1301,7 +1301,6 @@ impl Get<InteriorLocation> for BrokerPot {
 impl coretime::Config for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
 	type RuntimeEvent = RuntimeEvent;
-	type Currency = Balances;
 	type BrokerId = BrokerId;
 	type WeightInfo = weights::runtime_parachains_coretime::WeightInfo<Runtime>;
 	type SendXcm = crate::xcm_config::XcmRouter;
@@ -1466,8 +1465,7 @@ impl pallet_nomination_pools::Config for Runtime {
 	type MaxPointsToBalance = MaxPointsToBalance;
 	type WeightInfo = weights::pallet_nomination_pools::WeightInfo<Self>;
 	type AdminOrigin = EitherOf<EnsureRoot<AccountId>, StakingAdmin>;
-	// TODO: this will come back later (stable25XY)
-	// type Filter = pallet_staking::AllStakers<Runtime>;
+	type Filter = pallet_staking::AllStakers<Runtime>;
 	type BlockNumberProvider = System;
 }
 

--- a/relay/polkadot/src/xcm_config.rs
+++ b/relay/polkadot/src/xcm_config.rs
@@ -23,7 +23,7 @@ use super::{
 };
 use frame_support::{
 	parameter_types,
-	traits::{Contains, Equals, Everything, Nothing},
+	traits::{Contains, Disabled, Equals, Everything, Nothing},
 };
 use frame_system::EnsureRoot;
 use pallet_xcm::XcmPassthrough;
@@ -245,6 +245,7 @@ impl xcm_executor::Config for XcmConfig {
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
+	type XcmEventEmitter = XcmPallet;
 }
 
 parameter_types! {
@@ -328,4 +329,6 @@ impl pallet_xcm::Config for Runtime {
 	type RemoteLockConsumerIdentifier = ();
 	type WeightInfo = crate::weights::pallet_xcm::WeightInfo<Runtime>;
 	type AdminOrigin = EnsureRoot<AccountId>;
+	// Aliasing is disabled: xcm_executor::Config::Aliasers allows `Nothing`.
+	type AuthorizedAliasConsideration = Disabled;
 }

--- a/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
@@ -157,6 +157,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]
 try-runtime = [
 	"cumulus-pallet-aura-ext/try-runtime",

--- a/system-parachains/asset-hubs/asset-hub-kusama/primitives/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-kusama/primitives/Cargo.toml
@@ -38,4 +38,5 @@ std = [
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"system-parachains-constants/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
@@ -205,7 +205,7 @@ impl frame_system::Config for Runtime {
 	type ExtensionsWeightInfo = weights::frame_system_extensions::WeightInfo<Runtime>;
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = cumulus_pallet_parachain_system::ParachainSetCode<Self>;
-	type MaxConsumers = frame_support::traits::ConstU32<256>;
+w	type MaxConsumers = ConstU32<256>;
 	type SingleBlockMigrations = ();
 	type MultiBlockMigrator = ();
 	type PreInherents = ();
@@ -323,6 +323,7 @@ impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
 	type ApprovalDeposit = ExistentialDeposit;
 	type StringLimit = AssetsStringLimit;
 	type Freezer = ();
+	type Holder = ();
 	type Extra = ();
 	type WeightInfo = weights::pallet_assets_local::WeightInfo<Runtime>;
 	type CallbackHandle = pallet_assets::AutoIncAssetId<Runtime, TrustBackedAssetsInstance>;
@@ -364,6 +365,7 @@ impl pallet_assets::Config<PoolAssetsInstance> for Runtime {
 	type ApprovalDeposit = ExistentialDeposit;
 	type StringLimit = ConstU32<50>;
 	type Freezer = ();
+	type Holder = ();
 	type Extra = ();
 	type WeightInfo = weights::pallet_assets_pool::WeightInfo<Runtime>;
 	type CallbackHandle = ();
@@ -467,6 +469,7 @@ impl pallet_assets::Config<ForeignAssetsInstance> for Runtime {
 	type ApprovalDeposit = ExistentialDeposit;
 	type StringLimit = ForeignAssetsAssetsStringLimit;
 	type Freezer = ();
+	type Holder = ();
 	type Extra = ();
 	type WeightInfo = weights::pallet_assets_foreign::WeightInfo<Runtime>;
 	type CallbackHandle = ();

--- a/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
@@ -156,6 +156,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]
 try-runtime = [
 	"cumulus-pallet-aura-ext/try-runtime",

--- a/system-parachains/asset-hubs/asset-hub-polkadot/primitives/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/primitives/Cargo.toml
@@ -38,4 +38,5 @@ std = [
 runtime-benchmarks = [
 	"frame-support/runtime-benchmarks",
 	"system-parachains-constants/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -345,6 +345,7 @@ impl pallet_assets::Config<TrustBackedAssetsInstance> for Runtime {
 	type ApprovalDeposit = ExistentialDeposit;
 	type StringLimit = AssetsStringLimit;
 	type Freezer = ();
+	type Holder = ();
 	type Extra = ();
 	type WeightInfo = weights::pallet_assets_local::WeightInfo<Runtime>;
 	type CallbackHandle = pallet_assets::AutoIncAssetId<Runtime, TrustBackedAssetsInstance>;
@@ -397,6 +398,7 @@ impl pallet_assets::Config<ForeignAssetsInstance> for Runtime {
 	type ApprovalDeposit = ExistentialDeposit;
 	type StringLimit = ForeignAssetsAssetsStringLimit;
 	type Freezer = ();
+	type Holder = ();
 	type Extra = ();
 	type WeightInfo = weights::pallet_assets_foreign::WeightInfo<Runtime>;
 	type CallbackHandle = ();
@@ -902,6 +904,7 @@ impl pallet_assets::Config<PoolAssetsInstance> for Runtime {
 	type ApprovalDeposit = ExistentialDeposit;
 	type StringLimit = ConstU32<50>;
 	type Freezer = ();
+	type Holder = ();
 	type Extra = ();
 	type CallbackHandle = ();
 	type WeightInfo = weights::pallet_assets_pool::WeightInfo<Runtime>;

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
@@ -237,6 +237,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]
 
 try-runtime = [

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/bridge_to_polkadot_config.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/bridge_to_polkadot_config.rs
@@ -28,6 +28,7 @@ use bp_messages::{
 	target_chain::FromBridgedChainMessagesProof, LegacyLaneId,
 };
 use bp_parachains::SingleParaStoredHeaderDataBuilder;
+use bp_relayers::RewardsAccountParams;
 use bp_runtime::Chain;
 use bridge_hub_common::xcm_version::XcmVersionOfDestAndRemoteBridge;
 use frame_support::{
@@ -91,11 +92,13 @@ pub type RelayersForLegacyLaneIdsMessagesInstance = ();
 /// Allows collect and claim rewards for relayers.
 impl pallet_bridge_relayers::Config<RelayersForLegacyLaneIdsMessagesInstance> for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type Reward = Balance;
+	type RewardBalance = Balance;
+	type Reward = RewardsAccountParams<LegacyLaneId>;
 	type PaymentProcedure = bp_relayers::PayRewardFromAccount<
 		pallet_balances::Pallet<Runtime>,
 		AccountId,
-		Self::LaneId,
+		LegacyLaneId,
+		Self::RewardBalance,
 	>;
 	type StakeAndSlash = pallet_bridge_relayers::StakeAndSlashNamed<
 		AccountId,
@@ -105,7 +108,7 @@ impl pallet_bridge_relayers::Config<RelayersForLegacyLaneIdsMessagesInstance> fo
 		RequiredStakeForStakeAndSlash,
 		RelayerStakeLease,
 	>;
-	type LaneId = LegacyLaneId;
+	type Balance = Balance;
 	type WeightInfo = weights::pallet_bridge_relayers::WeightInfo<Runtime>;
 }
 
@@ -162,7 +165,6 @@ pub type OnBridgeHubPolkadotRefundBridgeHubKusamaMessages = BridgeRelayersTransa
 		RelayersForLegacyLaneIdsMessagesInstance,
 		PriorityBoostPerMessage,
 	>,
-	LaneIdOf<Runtime, WithBridgeHubPolkadotMessagesInstance>,
 >;
 bp_runtime::generate_static_str_provider!(OnBridgeHubPolkadotRefundBridgeHubKusamaMessages);
 

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/genesis_config_presets.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/genesis_config_presets.rs
@@ -36,6 +36,7 @@ fn bridge_hub_kusama_genesis(
 				.cloned()
 				.map(|k| (k, BRIDGE_HUB_KUSAMA_ED * 4096 * 4096))
 				.collect(),
+			dev_accounts: None,
 		},
 		"parachainInfo": ParachainInfoConfig {
 			parachain_id: id,

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
@@ -827,18 +827,29 @@ mod benches {
 	use pallet_bridge_relayers::benchmarking::Config as BridgeRelayersConfig;
 
 	impl BridgeRelayersConfig for Runtime {
+		// TODO @bkontur: Check this out, please.
+		fn bench_reward() -> Self::Reward {
+			bp_relayers::RewardsAccountParams::new(
+				bp_messages::LegacyLaneId::default(),
+				*b"test",
+				bp_relayers::RewardsAccountOwner::ThisChain,
+			)
+		}
+
 		fn prepare_rewards_account(
 			account_params: bp_relayers::RewardsAccountParams<
 				LaneIdOf<Runtime, bridge_to_polkadot_config::WithBridgeHubPolkadotMessagesInstance>,
 			>,
 			reward: Balance,
-		) {
+		) -> Option<AccountId> {
 			let rewards_account = bp_relayers::PayRewardFromAccount::<
 				Balances,
 				AccountId,
 				bp_messages::LegacyLaneId,
+				Balance,
 			>::rewards_account(account_params);
-			Self::deposit_account(rewards_account, reward);
+			Self::deposit_account(rewards_account.clone(), reward);
+			Some(rewards_account)
 		}
 
 		fn deposit_account(account: AccountId, balance: Balance) {

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/xcm_config.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/xcm_config.rs
@@ -25,6 +25,7 @@ use frame_support::{
 	parameter_types,
 	traits::{tokens::imbalance::ResolveTo, ConstU32, Contains, Equals, Everything, Nothing},
 };
+use frame_support::traits::Disabled;
 use frame_system::EnsureRoot;
 use pallet_collator_selection::StakingPotAccountId;
 use pallet_xcm::XcmPassthrough;
@@ -219,6 +220,7 @@ impl xcm_executor::Config for XcmConfig {
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
 	type XcmRecorder = PolkadotXcm;
+	type XcmEventEmitter = PolkadotXcm;
 }
 
 /// Converts a local signed origin into an XCM `Location`.
@@ -264,6 +266,8 @@ impl pallet_xcm::Config for Runtime {
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type MaxRemoteLockConsumers = ConstU32<0>;
 	type RemoteLockConsumerIdentifier = ();
+	// Aliasing is disabled: xcm_executor::Config::Aliasers allows `Nothing`.
+	type AuthorizedAliasConsideration = Disabled;
 }
 
 impl cumulus_pallet_xcm::Config for Runtime {

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
@@ -270,6 +270,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]
 
 try-runtime = [
@@ -304,6 +305,7 @@ try-runtime = [
 	"snowbridge-pallet-outbound-queue/try-runtime",
 	"snowbridge-pallet-system/try-runtime",
 	"sp-runtime/try-runtime",
+	"snowbridge-runtime-common/try-runtime"
 ]
 
 # Enable metadata hash generation at compile time for the `CheckMetadataHash` extension.

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
@@ -108,9 +108,11 @@ snowbridge-beacon-primitives = { workspace = true }
 snowbridge-pallet-system = { workspace = true }
 snowbridge-system-runtime-api = { workspace = true }
 snowbridge-core = { workspace = true }
+snowbridge-merkle-tree.workspace = true
 snowbridge-pallet-ethereum-client = { workspace = true }
 snowbridge-pallet-inbound-queue = { workspace = true }
 snowbridge-pallet-outbound-queue = { workspace = true }
+snowbridge-outbound-queue-primitives.workspace = true
 snowbridge-outbound-queue-runtime-api = { workspace = true }
 snowbridge-router-primitives = { workspace = true }
 snowbridge-runtime-common = { workspace = true }
@@ -219,6 +221,8 @@ std = [
 	"xcm-executor/std",
 	"xcm-runtime-apis/std",
 	"xcm/std",
+	"snowbridge-outbound-queue-primitives/std",
+	"snowbridge-merkle-tree/std"
 ]
 
 runtime-benchmarks = [

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/primitives/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/primitives/Cargo.toml
@@ -56,4 +56,5 @@ runtime-benchmarks = [
 	"snowbridge-core/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
 	"system-parachains-constants/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/src/bridge_to_ethereum_config.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/src/bridge_to_ethereum_config.rs
@@ -24,6 +24,7 @@ pub use bp_bridge_hub_polkadot::snowbridge::{EthereumLocation, EthereumNetwork};
 use frame_support::{parameter_types, weights::ConstantMultiplier};
 use pallet_xcm::EnsureXcm;
 use parachains_common::{AccountId, Balance};
+use snowbridge_outbound_queue_primitives::v1::ConstantGasMeter;
 use snowbridge_beacon_primitives::{Fork, ForkVersions};
 use snowbridge_core::AllowSiblingsOnly;
 use snowbridge_router_primitives::{inbound::MessageToXcm, outbound::EthereumBlobExporter};
@@ -85,7 +86,7 @@ impl snowbridge_pallet_outbound_queue::Config for Runtime {
 	type Decimals = ConstU8<10>;
 	type MaxMessagePayloadSize = ConstU32<2048>;
 	type MaxMessagesPerBlock = ConstU32<32>;
-	type GasMeter = snowbridge_core::outbound::ConstantGasMeter;
+	type GasMeter = ConstantGasMeter;
 	type Balance = Balance;
 	type WeightToFee = WeightToFee;
 	type WeightInfo = crate::weights::snowbridge_pallet_outbound_queue::WeightInfo<Runtime>;

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/src/bridge_to_kusama_config.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/src/bridge_to_kusama_config.rs
@@ -29,6 +29,7 @@ use bp_messages::{
 	target_chain::FromBridgedChainMessagesProof, LegacyLaneId,
 };
 use bp_parachains::SingleParaStoredHeaderDataBuilder;
+use bp_relayers::RewardsAccountParams;
 use bp_runtime::Chain;
 use bridge_hub_common::xcm_version::XcmVersionOfDestAndRemoteBridge;
 use frame_support::{
@@ -92,11 +93,13 @@ pub type RelayersForLegacyLaneIdsMessagesInstance = ();
 /// Allows collect and claim rewards for relayers.
 impl pallet_bridge_relayers::Config<RelayersForLegacyLaneIdsMessagesInstance> for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type Reward = Balance;
+	type RewardBalance = Balance;
+	type Reward = RewardsAccountParams<LegacyLaneId>;
 	type PaymentProcedure = bp_relayers::PayRewardFromAccount<
 		pallet_balances::Pallet<Runtime>,
 		AccountId,
-		Self::LaneId,
+		LegacyLaneId,
+		Self::RewardBalance,
 	>;
 	type StakeAndSlash = pallet_bridge_relayers::StakeAndSlashNamed<
 		AccountId,
@@ -106,7 +109,7 @@ impl pallet_bridge_relayers::Config<RelayersForLegacyLaneIdsMessagesInstance> fo
 		RequiredStakeForStakeAndSlash,
 		RelayerStakeLease,
 	>;
-	type LaneId = LegacyLaneId;
+	type Balance = Balance;
 	type WeightInfo = weights::pallet_bridge_relayers::WeightInfo<Runtime>;
 }
 
@@ -163,7 +166,6 @@ pub type OnBridgeHubPolkadotRefundBridgeHubKusamaMessages = BridgeRelayersTransa
 		RelayersForLegacyLaneIdsMessagesInstance,
 		PriorityBoostPerMessage,
 	>,
-	LaneIdOf<Runtime, WithBridgeHubKusamaMessagesInstance>,
 >;
 bp_runtime::generate_static_str_provider!(OnBridgeHubPolkadotRefundBridgeHubKusamaMessages);
 

--- a/system-parachains/collectives/collectives-polkadot/Cargo.toml
+++ b/system-parachains/collectives/collectives-polkadot/Cargo.toml
@@ -134,6 +134,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]
 try-runtime = [
 	"cumulus-pallet-aura-ext/try-runtime",

--- a/system-parachains/collectives/collectives-polkadot/src/genesis_config_presets.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/genesis_config_presets.rs
@@ -34,6 +34,7 @@ fn collectives_polkadot_genesis(
 				.cloned()
 				.map(|k| (k, COLLECTIVES_POLKADOT_ED * 4096 * 4096))
 				.collect(),
+			dev_accounts: None,
 		},
 		"parachainInfo": ParachainInfoConfig {
 			parachain_id: id,

--- a/system-parachains/collectives/collectives-polkadot/src/xcm_config.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/xcm_config.rs
@@ -23,6 +23,7 @@ use frame_support::{
 	parameter_types,
 	traits::{tokens::imbalance::ResolveTo, ConstU32, Contains, Equals, Everything, Nothing},
 };
+use frame_support::traits::Disabled;
 use frame_system::EnsureRoot;
 use pallet_xcm::XcmPassthrough;
 use parachains_common::xcm_config::{
@@ -245,6 +246,7 @@ impl xcm_executor::Config for XcmConfig {
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
+	type XcmEventEmitter = PolkadotXcm;
 }
 
 /// Converts a local signed origin into an XCM `Location`.
@@ -293,6 +295,8 @@ impl pallet_xcm::Config for Runtime {
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type MaxRemoteLockConsumers = ConstU32<0>;
 	type RemoteLockConsumerIdentifier = ();
+	// Aliasing is disabled: xcm_executor::Config::Aliasers only allows some privileged locations.
+	type AuthorizedAliasConsideration = Disabled;
 }
 
 impl cumulus_pallet_xcm::Config for Runtime {

--- a/system-parachains/constants/Cargo.toml
+++ b/system-parachains/constants/Cargo.toml
@@ -40,4 +40,5 @@ runtime-benchmarks = [
 	"polkadot-primitives/runtime-benchmarks",
 	"polkadot-runtime-constants/runtime-benchmarks",
 	"sp-runtime/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]

--- a/system-parachains/coretime/coretime-kusama/Cargo.toml
+++ b/system-parachains/coretime/coretime-kusama/Cargo.toml
@@ -179,6 +179,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]
 
 try-runtime = [

--- a/system-parachains/coretime/coretime-kusama/src/coretime.rs
+++ b/system-parachains/coretime/coretime-kusama/src/coretime.rs
@@ -321,6 +321,7 @@ impl CoretimeInterface for CoretimeAllocator {
 
 parameter_types! {
 	pub const BrokerPalletId: PalletId = PalletId(*b"py/broke");
+	pub const MinimumCreditPurchase: Balance = UNITS / 10;
 }
 
 pub struct SovereignAccountOf;
@@ -347,4 +348,5 @@ impl pallet_broker::Config for Runtime {
 	type SovereignAccountOf = SovereignAccountOf;
 	type MaxAutoRenewals = ConstU32<100>;
 	type PriceAdapter = pallet_broker::CenterTargetPrice<Balance>;
+	type MinimumCreditPurchase = MinimumCreditPurchase;
 }

--- a/system-parachains/coretime/coretime-kusama/src/genesis_config_presets.rs
+++ b/system-parachains/coretime/coretime-kusama/src/genesis_config_presets.rs
@@ -37,6 +37,7 @@ fn coretime_kusama_genesis(
 				.cloned()
 				.map(|k| (k, CORETIME_KUSAMA_ED * 4096 * 4096))
 				.collect(),
+			dev_accounts: None,
 		},
 		"parachainInfo": ParachainInfoConfig {
 			parachain_id: id,

--- a/system-parachains/coretime/coretime-kusama/src/xcm_config.rs
+++ b/system-parachains/coretime/coretime-kusama/src/xcm_config.rs
@@ -24,6 +24,7 @@ use frame_support::{
 	parameter_types,
 	traits::{tokens::imbalance::ResolveTo, ConstU32, Contains, Equals, Everything, Nothing},
 };
+use frame_support::traits::Disabled;
 use frame_system::EnsureRoot;
 use pallet_xcm::XcmPassthrough;
 use parachains_common::xcm_config::{
@@ -237,6 +238,7 @@ impl xcm_executor::Config for XcmConfig {
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
+	type XcmEventEmitter = PolkadotXcm;
 }
 
 /// Converts a local signed origin into an XCM `Location`. Forms the basis for local origins
@@ -282,6 +284,8 @@ impl pallet_xcm::Config for Runtime {
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type MaxRemoteLockConsumers = ConstU32<0>;
 	type RemoteLockConsumerIdentifier = ();
+	// Aliasing is disabled: xcm_executor::Config::Aliasers only allows some privileged locations.
+	type AuthorizedAliasConsideration = Disabled;
 }
 
 impl cumulus_pallet_xcm::Config for Runtime {

--- a/system-parachains/coretime/coretime-polkadot/Cargo.toml
+++ b/system-parachains/coretime/coretime-polkadot/Cargo.toml
@@ -181,6 +181,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]
 
 try-runtime = [

--- a/system-parachains/coretime/coretime-polkadot/src/coretime.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/coretime.rs
@@ -318,6 +318,7 @@ impl CoretimeInterface for CoretimeAllocator {
 
 parameter_types! {
 	pub const BrokerPalletId: PalletId = PalletId(*b"py/broke");
+	pub const MinimumCreditPurchase: Balance = UNITS / 10;
 }
 
 pub struct SovereignAccountOf;
@@ -344,4 +345,5 @@ impl pallet_broker::Config for Runtime {
 	type SovereignAccountOf = SovereignAccountOf;
 	type MaxAutoRenewals = ConstU32<100>;
 	type PriceAdapter = pallet_broker::CenterTargetPrice<Balance>;
+	type MinimumCreditPurchase = MinimumCreditPurchase;
 }

--- a/system-parachains/coretime/coretime-polkadot/src/genesis_config_presets.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/genesis_config_presets.rs
@@ -37,6 +37,7 @@ fn coretime_polkadot_genesis(
 				.cloned()
 				.map(|k| (k, CORETIME_POLKADOT_ED * 4096 * 4096))
 				.collect(),
+			dev_accounts: None,
 		},
 		"parachainInfo": ParachainInfoConfig {
 			parachain_id: id,

--- a/system-parachains/coretime/coretime-polkadot/src/xcm_config.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/xcm_config.rs
@@ -24,6 +24,7 @@ use frame_support::{
 	parameter_types,
 	traits::{tokens::imbalance::ResolveTo, ConstU32, Contains, Equals, Everything, Nothing},
 };
+use frame_support::traits::Disabled;
 use frame_system::EnsureRoot;
 use pallet_xcm::XcmPassthrough;
 use parachains_common::xcm_config::{
@@ -260,6 +261,7 @@ impl xcm_executor::Config for XcmConfig {
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
+	type XcmEventEmitter = PolkadotXcm;
 }
 
 /// Converts a local signed origin into an XCM `Location`. Forms the basis for local origins
@@ -305,6 +307,8 @@ impl pallet_xcm::Config for Runtime {
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type MaxRemoteLockConsumers = ConstU32<0>;
 	type RemoteLockConsumerIdentifier = ();
+	// Aliasing is disabled: xcm_executor::Config::Aliasers only allows some privileged locations.
+	type AuthorizedAliasConsideration = Disabled;
 }
 
 impl cumulus_pallet_xcm::Config for Runtime {

--- a/system-parachains/gluttons/glutton-kusama/Cargo.toml
+++ b/system-parachains/gluttons/glutton-kusama/Cargo.toml
@@ -69,6 +69,7 @@ runtime-benchmarks = [
 	"system-parachains-constants/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]
 std = [
 	"codec/std",

--- a/system-parachains/people/people-kusama/Cargo.toml
+++ b/system-parachains/people/people-kusama/Cargo.toml
@@ -183,6 +183,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]
 
 try-runtime = [

--- a/system-parachains/people/people-polkadot/Cargo.toml
+++ b/system-parachains/people/people-polkadot/Cargo.toml
@@ -180,6 +180,7 @@ runtime-benchmarks = [
 	"xcm-builder/runtime-benchmarks",
 	"xcm-executor/runtime-benchmarks",
 	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks"
 ]
 
 try-runtime = [


### PR DESCRIPTION
Passing building for

- `staging-kusama-runtime`
- `polkadot-runtime`
- `bridge-hub-kusama-runtime`
- `collectives-polkadot-runtime`
- `coretime-kusama-runtime`
- `coretime-polkadot-runtime`
- `gluttons-kusama-runtime`
- `bridge-hub-kusama-runtime`

The following runtimes are not passing due to the following error:

```rust
  --- stderr
     Compiling bridge-hub-polkadot-runtime v1.0.0 (/Users/pandres95/Documents/Virto/Development/Fellowship/runtimes/system-parachains/bridge-hubs/bridge-hub-polkadot)
  error[E0152]: duplicate lang item in crate `sp_io` (which `frame_support` depends on): `panic_impl`
    |
    = note: the lang item is first defined in crate `sp_io` (which `bridge_hub_polkadot_runtime` depends on)
    = note: first definition in `sp_io` loaded from /Users/pandres95/Documents/Virto/Development/Fellowship/runtimes/target/debug/wbuild/bridge-hub-polkadot-runtime/target/wasm32v1-none/release/deps/libsp_io-c33aafce384cdcd6.rmeta
    = note: second definition in `sp_io` loaded from /Users/pandres95/Documents/Virto/Development/Fellowship/runtimes/target/debug/wbuild/bridge-hub-polkadot-runtime/target/wasm32v1-none/release/deps/libsp_io-1b25a099d7782c25.rmeta

  For more information about this error, try `rustc --explain E0152`.
  error: could not compile `bridge-hub-polkadot-runtime` (lib) due to 1 previous error

```

- `asset-hub-kusama-runtime`
- `asset-hub-polkadot-runtime`
- `bridge-hub-polkadot-runtime`