### PR TITLE
Remove dual stake filter

### DIFF
--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -862,7 +862,7 @@ impl pallet_staking::Config for Runtime {
 	type BenchmarkingConfig = polkadot_runtime_common::StakingBenchmarkingConfig;
 	type EventListeners = (NominationPools, DelegatedStaking);
 	type WeightInfo = weights::pallet_staking::WeightInfo<Runtime>;
-	type Filter = pallet_nomination_pools::AllPoolMembers<Runtime>;
+	type Filter = ();
 }
 
 impl pallet_fast_unstake::Config for Runtime {
@@ -1731,7 +1731,7 @@ impl pallet_nomination_pools::Config for Runtime {
 	type PalletId = PoolsPalletId;
 	type MaxPointsToBalance = MaxPointsToBalance;
 	type AdminOrigin = EitherOf<EnsureRoot<AccountId>, StakingAdmin>;
-	type Filter = pallet_staking::AllStakers<Runtime>;
+	type Filter = ();
 	type BlockNumberProvider = System;
 }
 
@@ -3114,55 +3114,6 @@ mod multiplier_tests {
 			});
 			blocks += 1;
 		}
-	}
-}
-
-#[cfg(test)]
-mod staking_tests {
-	use super::*;
-	use frame_support::{assert_noop, assert_ok, traits::fungible::Mutate};
-
-	#[test]
-	fn accounts_cannot_dual_stake() {
-		let mut ext = sp_io::TestExternalities::new_empty();
-		ext.execute_with(|| {
-			let stake = ExistentialDeposit::get() * 10;
-			// Given a solo staker
-			let solo_staker = AccountId::from([1u8; 32]);
-			Balances::set_balance(&solo_staker, 3 * stake);
-			assert_ok!(Staking::bond(
-				RuntimeOrigin::signed(solo_staker.clone()),
-				stake,
-				pallet_staking::RewardDestination::Stash
-			));
-
-			// And a pooled staker
-			let pooled_staker = AccountId::from([2u8; 32]);
-			Balances::set_balance(&pooled_staker, 3 * stake);
-			assert_ok!(NominationPools::create(
-				RuntimeOrigin::signed(pooled_staker.clone()),
-				stake,
-				pooled_staker.clone().into(),
-				pooled_staker.clone().into(),
-				pooled_staker.clone().into()
-			));
-
-			// Then the solo staker cannot join a pool.
-			assert_noop!(
-				NominationPools::join(RuntimeOrigin::signed(solo_staker), stake, 1),
-				pallet_nomination_pools::Error::<Runtime>::Restricted
-			);
-
-			// And the pooled staker cannot solo-stake.
-			assert_noop!(
-				pallet_staking::Pallet::<Runtime>::bond(
-					RuntimeOrigin::signed(pooled_staker),
-					stake,
-					pallet_staking::RewardDestination::Stash,
-				),
-				pallet_staking::Error::<Runtime>::Restricted
-			);
-		});
 	}
 }
 


### PR DESCRIPTION
With polkadot-sdk stable2503, staking will migrate to using holds instead of locks.
This change gets rid of the issue of overlapping locks with other pallets, resolving the main reason we previously restricted simultaneous participation in both staking and nomination pools.

This change removes the above restriction, and re-allows accounts to participate in both types of staking simultaenously.

Related: https://github.com/paritytech/polkadot-sdk/issues/5742